### PR TITLE
reduce padding on main for greater area for content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,7 +27,7 @@ body {
 /* General Styles */
 
 main {
-	padding: 2em; 
+	padding: 0.8em; 
 }
 
 h2, h3, h4, h5, h6, p {


### PR DESCRIPTION
The 2em padding on main works great on paragraphs going from edge to edge. But as soon as some indentation is needed by any component, the 2 ems can seem a waste.